### PR TITLE
Hydrogen addon without transmission investments

### DIFF
--- a/base/addons/hydrogen/bb4/hydrogen_eqndecdef.inc
+++ b/base/addons/hydrogen/bb4/hydrogen_eqndecdef.inc
@@ -257,6 +257,8 @@ $ifi %DECOM%==yes   -VDECOM_EXO_ACCUM(IY411,IA,IHYDROGEN_GH2TOBIOMETH)$IGDECOMEX
 
 EQUATIONS
 QXH2K_UP(Y,IRRRE,IRRRI,S,T)           "H2 transmission capacity constraint (MW)"
+
+$iftheni %H2TransInvest%==yes
 QXH2KNACCUMNET(Y,IRRRE,IRRRI)         "NOT FINISHED, TODO, Accumulated new H2 transmission investments available at beginning of next year (MW)"
 QXH2KNACCUMNET_NGTOH2(Y,IRRRE,IRRRI)  "NOT FINISHED, TODO, Accumulated new investments in conversion of existing natural gas pipe to H2 transmission available at beginning of next year (MW)"
 QXH2INVSYMMETRY(Y,IRRRE,IRRRI)        "H2 Transmission investments are set symetric(MW)"
@@ -265,17 +267,19 @@ QXH2KMAX_NGTOH2(Y,IRRRE,IRRRI)        "Maximum conversion of existing natural ga
 *Equations for modelling economy of scale
 QVXH2KN_ES(YYY,IRRRE,IRRRI)  "Equation to ensure the proper H2 capacity when using SOS2 variables"
 QXH2LAMBDA_ES(YYY,IRRRE,IRRRI) "Equation to ensure all the Lambda variables are equal to 1 for the same H2 transmission line"
+$endif
 ;
 
 *"H2 transmission capacity constraint (MW)"
 QXH2K_UP(IY411,IRE,IRI,IS3,T)$(SUM(Y$(YVALUE(Y) LE YVALUE(IY411)),IXH2KN(Y,IRE,IRI)) OR SUM(Y$(YVALUE(Y) LE YVALUE(IY411)),IXH2KN_NGTOH2(Y,IRE,IRI)))..
    (  XH2KFX(IY411,IRE,IRI)
-      + VXH2KNACCUMNET(IY411,IRE,IRI)$SUM(Y$(YVALUE(Y) LE YVALUE(IY411)),IXH2KN(Y,IRE,IRI))
-      + VXH2KNACCUMNET_NGTOH2(IY411,IRE,IRI)$SUM(Y$(YVALUE(Y) LE YVALUE(IY411)),IXH2KN_NGTOH2(Y,IRE,IRI))
+$ifi %H2TransInvest%==yes      + VXH2KNACCUMNET(IY411,IRE,IRI)$SUM(Y$(YVALUE(Y) LE YVALUE(IY411)),IXH2KN(Y,IRE,IRI))
+$ifi %H2TransInvest%==yes      + VXH2KNACCUMNET_NGTOH2(IY411,IRE,IRI)$SUM(Y$(YVALUE(Y) LE YVALUE(IY411)),IXH2KN_NGTOH2(Y,IRE,IRI))
     )*(1$(NOT IXH2KRATE(IRE,IRI,IS3,T))+IXH2KRATE(IRE,IRI,IS3,T))
      =G=  VXH2_T(IY411,IRE,IRI,IS3,T)
 ;
 
+$ifi not %H2TransInvest%==yes $goto no_transmission_investments
 *"NOT FINISHED, TODO, Accumulated new heat transmission investments available at beginning of next year (MW)"
 QXH2KNACCUMNET(IY411,IRE,IRI)$SUM(Y$(YVALUE(Y) LE YVALUE(IY411)),IXH2KN(Y,IRE,IRI))..
   VXH2KNACCUMNET(IY411,IRE,IRI)  !! End of this year's VXH2KNACCUMNET (available at beginning of next year)'
@@ -319,3 +323,5 @@ QVXH2KN_ES(IY411,IRE,IRI)$(IXH2KN(IY411,IRI,IRE) AND (IXH2KN_ES(IRE,IRI)))..
 
 QXH2LAMBDA_ES(IY411,IRE,IRI)$(IXH2KN(IY411,IRI,IRE) AND (IXH2KN_ES(IRE,IRI)))..
   SUM(XES,VXH2LAMBDA(IY411,IRE,IRI,XES)) =E= 1;
+
+$label no_transmission_investments

--- a/base/addons/hydrogen/bb4/hydrogen_qobj.inc
+++ b/base/addons/hydrogen/bb4/hydrogen_qobj.inc
@@ -58,6 +58,7 @@ $offtext
 + SUM((IRE,IRI)$IXH2K_HASORPOT(Y,IRE,IRI),
         SUM((IS3,T), IHOURFRAC*IHOURSINST(IS3,T) * (VXH2_T(Y,IRE,IRI,IS3,T) * XH2COST(IRE,IRI))))
 
+$ifi not %H2TransInvest%==yes $goto no_transmission_investments
 * Investment costs, new H2 transmission capacity
 * (the average of the annuities for the two countries in question is used for international transmission):
     + SUM((IRE,IRI)$((IXH2KN(Y,IRI,IRE) OR IXH2KN(Y,IRE,IRI)) AND (NOT (IXH2KN_ES(IRE,IRI) OR IXH2KN_ES(IRI,IRE)))),IOF05*VXH2KN(Y,IRE,IRI)*XH2INVCOST(Y,IRE,IRI)*
@@ -87,3 +88,4 @@ $ifi not %ES_H2TRANS%==yes $goto no_economy_of_scale
      VXH2LAMBDA(IYALIAS2,IRE,IRI,XES)*XH2INVCOST_ES(IYALIAS2,IRE,IRI,XES)*IOF05*
      (IOF05* (SUM(C$CCCRRR(C,IRE),ANNUITYCXH2(C))+SUM(C$CCCRRR(C,IRI),ANNUITYCXH2(C))))*IYHASANNUITYXH2(IYALIAS2,Y))
 $label no_economy_of_scale
+$label no_transmission_investments

--- a/base/addons/hydrogen/bb4/hydrogen_vardeclare.inc
+++ b/base/addons/hydrogen/bb4/hydrogen_vardeclare.inc
@@ -9,11 +9,13 @@ POSITIVE VARIABLES
    VBIOMETH_STOLOADT(Y,S,T)              'Loading of biomethane storage'
    VBIOMETH_STOUNLOADT(Y,S,T)            'Unloading of biomethane storage'
    VXH2_T(Y,IRRRE,IRRRI,S,T)             'H2 export from region IRRRE towards IRRRI (MW)'
+
+$iftheni %H2TransInvest%==yes
    VXH2KN(Y,IRRRE,IRRRI)                 'New H2 transmission capacity (MW)'
    VXH2KN_NGTOH2(Y,IRRRE,IRRRI)          'New Conversion of existing natural gas pipe to H2 transmission capacity (MW)'
    VXH2KNACCUMNET(Y,IRRRE,IRRRI)         'Accumulated new H2 transmission investments (MISSING: minus any decommissioning of them due to lifetime expiration) this BB4, at end of previous (i.e., available at start of current) year (MW)'
    VXH2KNACCUMNET_NGTOH2(Y,IRRRE,IRRRI)  'Accumulated new Conversion of existing natural gas pipe to H2 Transmission investments (MISSING: minus any decommissioning of them due to lifetime expiration) this BB4, at end of previous (i.e., available at start of current) year (MW)'
-
+$endif
 
 ;
 
@@ -25,5 +27,5 @@ VFLEXDH2_SHIFT(Y,RRR) 'how much to shift from one area to area'
 ; 
 $label no_flexible_h2_space
 
-SOS2 VARIABLE VXH2LAMBDA(Y,IRRRE,IRRRI,XES) 'SOS2 Variable for modelling economy of scale';
+$ifi %H2TransInvest%==yes SOS2 VARIABLE VXH2LAMBDA(Y,IRRRE,IRRRI,XES) 'SOS2 Variable for modelling economy of scale';
 

--- a/base/output/OUTPUT_SUMMARY.inc
+++ b/base/output/OUTPUT_SUMMARY.inc
@@ -1262,7 +1262,7 @@ $label No_HEATTRANS_costs
 
 *Hydrogen
 $ifi not %HYDROGEN%==yes $goto No_H2TRANS_costs
-
+$ifi not %H2TransInvest%==yes $goto H2_Transmission_investment_cost_end
 ** TRANSMISSION INVESTMENTS
 ECO_XH2_YCR(Y,C,IR,IRI,'COSTS','H2_TRANSMISSION_CAPITAL_COSTS','Mmoney')$(CCCRRR(C,IR) AND IXH2K_HASORPOT(Y,IR,IRI))=
           OMONEY*IOF0000001*(SUM((IYALIAS2)$((IXH2KN(IYALIAS2,IRI,IR) OR IXH2KN(IYALIAS2,IR,IRI)) AND (NOT (IXKN_ES(IR,IRI) OR IXKN_ES(IRI,IR)))  AND ORD(IYALIAS2) LE ORD(Y)) ,
@@ -1274,6 +1274,7 @@ $ifi %ES_H2TRANS%==yes      IOF05*ANNUITYCXH2(C)*IYHASANNUITYXH2(IYALIAS2,Y)*SUM
 $ifi %ES_H2TRANS%==yes                           )
                             )
 ;
+$label  H2_Transmission_investment_cost_end
 
 ** TRANSMISSION FLOW
 ECO_XH2_YCR(Y,C,IR,IRI,'COSTS','H2_TRANSMISSION_OPERATIONAL_COSTS','Mmoney')$(CCCRRR(C,IR) AND IXH2K_HASORPOT(Y,IR,IRI))=


### PR DESCRIPTION
I adapted the hydrogen addon, so one can run it without the transmission investments. I have seen that there exists a new version for running it without the economies of scale as well. It is interesting that you can declare SOS2 VARIABLE VXH2LAMBDA and there is no error running it as LP.