### PR TITLE
Updated documentation on USEOPTIONFILE file for HPC runs

### DIFF
--- a/base/documentation/gh-pages/docs_environment.yml
+++ b/base/documentation/gh-pages/docs_environment.yml
@@ -2,7 +2,8 @@ name: docs_building
 channels:
   - conda-forge
 dependencies:
-  - python=3.12
+  - python=3.14
+  - setuptools >=81,<=81
   - myst-parser
   - sphinx
   - sphinx-rtd-theme

--- a/base/documentation/gh-pages/get_started/scenario_setup.md
+++ b/base/documentation/gh-pages/get_started/scenario_setup.md
@@ -1,5 +1,5 @@
 # Scenario Setup
-Lets start by learning how to execute Balmorel using a small test scenario. Create a new folder in the level of the base folder, a new data and model folder inside of this and copy and paste the Balmorel.gms and cplex.op4 folder from base/model. If you want to call this scenario "test_run" the folder structure should now look like the following:
+Lets start by learning how to execute Balmorel using a small test scenario. Create a new folder in the level of the base folder, a new data and model folder inside of this and copy and paste the Balmorel.gms and cplex.op4 folder from base/model (copy cplex.op2 instead of cplex.op4 if running on HPC). If you want to call this scenario "test_run" the folder structure should now look like the following:
 ```bash
 Balmorel
 ├── base
@@ -53,4 +53,4 @@ DENMARK
 ```
 This selects countries Norway and Denmark (which consist of respectively 5 and 2 electricity and hydrogen nodes, corresponding to the bidding zones of Norway and Denmark).
 
-We are now ready to run Balmorel, see the next page.
+We are now ready to run Balmorel, see the next page.

--- a/base/documentation/gh-pages/running_on_hpc/submitting_a_job.md
+++ b/base/documentation/gh-pages/running_on_hpc/submitting_a_job.md
@@ -13,7 +13,7 @@ After having transferred our Balmorel model through WinSCP (see [previous page](
 The bottom commands assumes that the job script is submitted from inside your Balmorel folder, and that your Balmorel project contains a "scenario1" scenario - see [how to create new scenarios](../get_started/scenario_setup.md). The `threads=$LSB_DJOB_NUMPROC` command makes sure that Balmorel does not use more cores than defined  in your job script (four in this case, due to `#BSUB -n 4`)
 
 :::{warning}
-Make sure to copy the `cplex.op2` file to each scenario/model folder. The `--USEOPTIONFILE=2` option passed to the gams command in the example below tells Balmorel to look for this file, which makes sure that CPLEX use more HPC threads than requested. Note that this can also be changed in the `base/model/balgams.opt` file by setting `$Setglobal USEOPTIONFILE 2`. 
+Make sure to copy the `cplex.op2` file to each scenario/model folder. The `--USEOPTIONFILE=2` option passed to the gams command in the example below tells Balmorel to look for this file, which makes sure that CPLEX doesn't use more HPC threads than requested. Note that this can also be changed in the `base/model/balgams.opt` file by setting `$Setglobal USEOPTIONFILE 2`. 
 :::
 
 ```bash

--- a/base/documentation/gh-pages/running_on_hpc/submitting_a_job.md
+++ b/base/documentation/gh-pages/running_on_hpc/submitting_a_job.md
@@ -13,7 +13,7 @@ After having transferred our Balmorel model through WinSCP (see [previous page](
 The bottom commands assumes that the job script is submitted from inside your Balmorel folder, and that your Balmorel project contains a "scenario1" scenario - see [how to create new scenarios](../get_started/scenario_setup.md). The `threads=$LSB_DJOB_NUMPROC` command makes sure that Balmorel does not use more cores than defined  in your job script (four in this case, due to `#BSUB -n 4`)
 
 :::{warning}
-Please make sure to switch to the solver options file `cplex.op2`, by going into the `balgams.opt` file and setting `$Setglobal USEOPTIONFILE 2`. Otherwise CPLEX will overwrite the number of chosen threads and will ue more resources than requested.
+Make sure to copy the `cplex.op2` file to each scenario/model folder. The `--USEOPTIONFILE=2` option passed to the gams command in the example below tells Balmorel to look for this file, which makes sure that CPLEX use more HPC threads than requested. Note that this can also be changed in the `base/model/balgams.opt` file by setting `$Setglobal USEOPTIONFILE 2`. 
 :::
 
 ```bash
@@ -53,7 +53,7 @@ export LD_LIBRARY_PATH=/appl/gams/47.6.0:$LD_LIBRARY_PATH
 # Go to model folder of your scenario - this assumes that the job script is at the same level of the Balmorel folder
 cd scenario1/model 
 # Run Balmorel
-gams Balmorel threads=$LSB_DJOB_NUMPROC
+gams Balmorel threads=$LSB_DJOB_NUMPROC --USEOPTIONFILE=2
 ```
 
 ## Submitting the Job from PuTTY


### PR DESCRIPTION
I find it more intuitive to pass --USEOPTIONFILE=2 on the HPC gams command rather than change balgams.opt, which makes it more seamless to switch between local testing and HPC running if using git.

This lead me to make these changes to the documentation (i.e.: our 'best practice' recommendations).

Let me know if you agree!